### PR TITLE
Changing the order of then and catch

### DIFF
--- a/src/source/StatusCode.js
+++ b/src/source/StatusCode.js
@@ -15,7 +15,14 @@ export default class StatusCode extends Source {
 
     getStatus() {
         return this.fetchData()
-            .catch(response => {
+            .then(() => {
+                return {
+                    title: this.title,
+                    link: this.link,
+                    status: "success",
+                    messages: []
+                };
+            }).catch(response => {
                 return {
                     title: this.title,
                     link: this.link,
@@ -23,14 +30,6 @@ export default class StatusCode extends Source {
                     messages: [{
                         message: "Response had status code " + response.status
                     }]
-                };
-            })
-            .then(() => {
-                return {
-                    title: this.title,
-                    link: this.link,
-                    status: "success",
-                    messages: []
                 };
             });
     }


### PR DESCRIPTION
With the order of then and catch changed, I get a correct response in the dashboard. Without this change, everything is green, even with 500 / 400 HTTP status codes. I've tested this (grunt dev) with Chromium and Firefox on Ubuntu 17.10.